### PR TITLE
Add embedded storage and embedded DNS server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*.sw*
 /target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -154,6 +163,19 @@ checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
 ]
 
 [[package]]
@@ -332,6 +354,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +450,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -578,6 +619,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,6 +692,15 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -755,12 +814,37 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.1",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -848,6 +932,12 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "pretty-hex"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5c99d529f0d30937f6f4b8a86d988047327bb88d04d2c4afc356de74722131"
 
 [[package]]
 name = "proc-macro-error"
@@ -1103,6 +1193,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
 
 [[package]]
+name = "sled"
+version = "0.34.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
 name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,7 +1435,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1384,10 +1490,15 @@ dependencies = [
  "anyhow",
  "clap",
  "dropshot",
+ "pretty-hex",
+ "schemars",
  "serde",
+ "serde_json",
+ "sled",
  "slog",
  "tokio",
  "toml",
+ "trust-dns-proto",
  "trust-dns-server",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,8 @@ slog = { version = "2.5.0", features = [ "max_level_trace", "release_max_level_d
 tokio = { version = "1.17", features = [ "full" ] }
 toml = "0.5"
 trust-dns-server = "0.21"
+trust-dns-proto = "0.21"
+pretty-hex = "0.2.1"
+schemars = "0.8"
+sled = "0.34"
+serde_json = "1"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# Toy DNS
+
+A minimal prototype for DNS functionality identified in RFD 248.
+
+## Usage
+
+Run the server
+
+```
+cargo run -- --config-file example-config.toml
+```
+
+Add some records
+
+```shell
+# AAAA
+./scripts/add-aaaa.sh pizza fd00::1701
+
+# SRV
+./scripts/add-srv.sh blueberry 47 47 47 muffin
+```
+
+View records through admin interface
+
+```shell
+curl -s localhost:5353/get-records | jq
+[
+  [
+    {
+      "name": "blueberry"
+    },
+    {
+      "SRV": [
+        47,
+        47,
+        47,
+        "muffin"
+      ]
+    }
+  ],
+  [
+    {
+      "name": "pizza"
+    },
+    {
+      "AAAA": "fd00::1701"
+    }
+  ]
+]
+```
+
+View records through `dig`.
+
+```shell
+dig -p 4753 pizza @localhost
+
+; <<>> DiG 9.10.6 <<>> -p 4753 pizza @localhost
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 1395
+;; flags: qr rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+;; WARNING: recursion requested but not available
+
+;; QUESTION SECTION:
+;pizza.				IN	A
+
+;; ANSWER SECTION:
+pizza.			0	IN	AAAA	fd00::1701
+
+;; Query time: 1 msec
+;; SERVER: ::1#4753(::1)
+;; WHEN: Sat Mar 12 08:40:52 PST 2022
+;; MSG SIZE  rcvd: 56
+```
+
+```shell
+dig -p 4753 blueberry @localhost
+
+; <<>> DiG 9.10.6 <<>> -p 4753 blueberry @localhost
+;; global options: +cmd
+;; Got answer:
+;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 24764
+;; flags: qr rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0
+;; WARNING: recursion requested but not available
+
+;; QUESTION SECTION:
+;blueberry.			IN	A
+
+;; ANSWER SECTION:
+blueberry.		0	IN	SRV	47 47 47 muffin.
+
+;; Query time: 1 msec
+;; SERVER: ::1#4753(::1)
+;; WHEN: Sat Mar 12 08:41:16 PST 2022
+;; MSG SIZE  rcvd: 62
+```

--- a/scripts/add-aaaa.sh
+++ b/scripts/add-aaaa.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ $# -ne 2 ]]; then
+    echo "usage: add-aaaa <name> <ipv6>"
+    exit 1
+fi
+
+curl -X PUT localhost:5353/set-records -d "[[{\"name\": \"$1\"}, {\"AAAA\": \"$2\"}]]"; echo;

--- a/scripts/add-srv.sh
+++ b/scripts/add-srv.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ $# -ne 5 ]]; then
+    echo "usage: add-aaaa <name> <prio> <weight> <port> <target>"
+    exit 1
+fi
+
+curl -X PUT localhost:5353/set-records \
+    -d "[[{\"name\": \"$1\"}, {\"SRV\": [$2, $3, $4, \"$5\"]}]]"
+
+echo;

--- a/scripts/delete-record.sh
+++ b/scripts/delete-record.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: delete-record <name>"
+    exit 1
+fi
+
+curl -X PUT localhost:5353/delete-records -d "[{\"name\": \"$1\"}]"; echo;

--- a/scripts/dig-muffins.sh
+++ b/scripts/dig-muffins.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dig -p 4753 muffins @localhost

--- a/scripts/get-records.sh
+++ b/scripts/get-records.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl localhost:5353/get-records; echo;

--- a/src/dns_data.rs
+++ b/src/dns_data.rs
@@ -1,8 +1,11 @@
 //! Manages DNS data (configured zone(s), records, etc.)
 
 use anyhow::Context;
-use serde::Deserialize;
-use slog::{info, o, trace};
+use serde::{Serialize, Deserialize};
+use schemars::JsonSchema;
+use slog::{info, o, trace, error};
+use std::net::Ipv6Addr;
+use std::sync::Arc;
 
 /// Configuration related to data model
 #[derive(Deserialize, Debug)]
@@ -21,10 +24,15 @@ impl Default for Config {
 }
 
 // XXX
-#[derive(Debug)]
-pub struct DnsRecord;
-#[derive(Debug)]
-pub struct DnsRecordKey;
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub enum DnsRecord {
+    AAAA(Ipv6Addr),
+    SRV(u16, u16, u16, String),
+}
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct DnsRecordKey {
+    name: String,
+}
 #[derive(Debug)]
 pub struct DnsResponse<T> {
     tx: tokio::sync::oneshot::Sender<T>,
@@ -41,7 +49,9 @@ pub enum DnsCmd {
     // XXX
     // MakeExist(DnsRecord, DnsResponse<()>),
     // MakeGone(DnsRecordKey, DnsResponse<()>),
-    GetRecords(DnsRecordKey, DnsResponse<Vec<DnsRecord>>),
+    GetRecords(Option<DnsRecordKey>, DnsResponse<Vec<(DnsRecordKey,DnsRecord)>>),
+    SetRecords(Vec<(DnsRecordKey,DnsRecord)>, DnsResponse<()>),
+    DeleteRecords(Vec<DnsRecordKey>, DnsResponse<()>),
 }
 
 /// Data model client
@@ -54,11 +64,18 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn new(log: slog::Logger, config: &Config) -> Client {
+    pub fn new(
+        log: slog::Logger,
+        config: &Config,
+        db: Arc::<sled::Db>,
+    ) -> Client {
         let (sender, receiver) =
             tokio::sync::mpsc::channel(config.nmax_messages);
-        let server =
-            Server { log: log.new(o!("component" => "DataServer")), receiver };
+        let server = Server {
+            log: log.new(o!("component" => "DataServer")),
+            receiver,
+            db
+        };
         tokio::spawn(async move { data_server(server).await });
         Client { log, sender }
     }
@@ -66,12 +83,38 @@ impl Client {
     // XXX error type needs to be rich enough for appropriate HTTP response
     pub async fn get_records(
         &self,
-        key: DnsRecordKey,
-    ) -> Result<Vec<DnsRecord>, anyhow::Error> {
+        key: Option<DnsRecordKey>,
+    ) -> Result<Vec<(DnsRecordKey,DnsRecord)>, anyhow::Error> {
         slog::trace!(&self.log, "get_records"; "key" => ?key);
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.sender
             .try_send(DnsCmd::GetRecords(key, DnsResponse { tx }))
+            .context("send message")?;
+        rx.await.context("recv response")
+    }
+
+    // XXX error type needs to be rich enough for appropriate HTTP response
+    pub async fn set_records(
+        &self,
+        records: Vec<(DnsRecordKey,DnsRecord)>,
+    ) -> Result<(), anyhow::Error> {
+        slog::trace!(&self.log, "set_records"; "records" => ?records);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.sender
+            .try_send(DnsCmd::SetRecords(records, DnsResponse { tx }))
+            .context("send message")?;
+        rx.await.context("recv response")
+    }
+
+    // XXX error type needs to be rich enough for appropriate HTTP response
+    pub async fn delete_records(
+        &self,
+        records: Vec<DnsRecordKey>,
+    ) -> Result<(), anyhow::Error> {
+        slog::trace!(&self.log, "delete_records"; "records" => ?records);
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.sender
+            .try_send(DnsCmd::DeleteRecords(records, DnsResponse { tx }))
             .context("send message")?;
         rx.await.context("recv response")
     }
@@ -95,6 +138,12 @@ async fn data_server(mut server: Server) {
             DnsCmd::GetRecords(key, response) => {
                 server.cmd_get_records(key, response).await;
             }
+            DnsCmd::SetRecords(records, response) => {
+                server.cmd_set_records(records, response).await;
+            }
+            DnsCmd::DeleteRecords(records, response) => {
+                server.cmd_delete_records(records, response).await;
+            }
         }
     }
 }
@@ -103,15 +152,168 @@ async fn data_server(mut server: Server) {
 pub struct Server {
     log: slog::Logger,
     receiver: tokio::sync::mpsc::Receiver<DnsCmd>,
+    db: Arc::<sled::Db>,
 }
 
 impl Server {
     async fn cmd_get_records(
         &self,
-        key: DnsRecordKey,
-        response: DnsResponse<Vec<DnsRecord>>,
+        key: Option<DnsRecordKey>,
+        response: DnsResponse<Vec<(DnsRecordKey, DnsRecord)>>,
     ) {
-        // XXX
-        // response.send(Vec::new());
+
+        // If a key is provided search just for that key. Otherwise return all
+        // the db entries.
+        if let Some(key) = key {
+            let bits = match self.db.get(key.name.as_bytes()){
+                Ok(Some(bits)) => bits,
+                _ => {
+                    match response.tx.send(Vec::new()) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            error!(self.log, "response tx: {:?}", e);
+                        }
+                    }
+                    return;
+                }
+            };
+            let record: DnsRecord =
+                match serde_json::from_slice(bits.as_ref()) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        error!(self.log, "deserialize record: {}", e);
+                        match response.tx.send(Vec::new()) {
+                            Ok(_) => {}
+                            Err(e) => {
+                                error!(self.log, "response tx: {:?}", e);
+                            }
+                        }
+                        return;
+                    }
+                };
+            match response.tx.send(vec![(key,record)]) {
+                Ok(_) => {}
+                Err(e) => {
+                    error!(self.log, "response tx: {:?}", e);
+                }
+            }
+        } else {
+            let mut result = Vec::new();
+            let mut iter = self.db.iter();
+            loop {
+                match iter.next() {
+                    Some(Ok((k,v))) => {
+                        let record: DnsRecord =
+                            match serde_json::from_slice(v.as_ref()) {
+                                Ok(r) => r,
+                                Err(e) => {
+                                    error!(self.log, "deserialize record: {}", e);
+                                    match response.tx.send(Vec::new()) {
+                                        Ok(_) => {}
+                                        Err(e) => {
+                                            error!(self.log, "response tx: {:?}", e);
+                                        }
+                                    }
+                                    return;
+                                }
+                            };
+                        let key = match std::str::from_utf8(k.as_ref()) {
+                            Ok(s) => s.to_string(),
+                            Err(e) => {
+                                error!(self.log, "key encoding: {}", e);
+                                match response.tx.send(Vec::new()) {
+                                    Ok(_) => {}
+                                    Err(e) => {
+                                        error!(self.log, "response tx: {:?}", e);
+                                    }
+                                }
+                                return;
+                            }
+                        };
+                        result.push((DnsRecordKey{name: key}, record));
+                    }
+                    Some(Err(e)) => {
+                        error!(self.log, "db iteration error: {}", e);
+                        break;
+                    }
+                    None => break,
+                }
+            }
+            match response.tx.send(result) {
+                Ok(_) => {}
+                Err(e) => {
+                    error!(self.log, "response tx: {:?}", e);
+                }
+            }
+        }
+    }
+
+    async fn cmd_set_records(
+        &self,
+        records: Vec<(DnsRecordKey,DnsRecord)>,
+        response: DnsResponse<()>,
+    ) {
+        for (k,v) in records {
+            let bits = match serde_json::to_string(&v) {
+                Ok(bits) => bits,
+                Err(e) => {
+                    error!(self.log, "serialize record: {}", e);
+                    match response.tx.send(()) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            error!(self.log, "response tx: {:?}", e);
+                        }
+                    }
+                    return;
+                }
+            };
+            match self.db.insert(k.name.as_bytes(), bits.as_bytes()) {
+                Ok(_) => {}
+                Err(e) => {
+                    error!(self.log, "db insert: {}", e);
+                    match response.tx.send(()) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            error!(self.log, "response tx: {:?}", e);
+                        }
+                    }
+                    return;
+                }
+            }
+        }
+        match response.tx.send(()) {
+            Ok(_) => {}
+            Err(e) => {
+                error!(self.log, "response tx: {:?}", e);
+            }
+        }
+    }
+
+    async fn cmd_delete_records(
+        &self,
+        records: Vec<DnsRecordKey>,
+        response: DnsResponse<()>,
+    ) {
+        for k in records {
+            match self.db.remove(k.name.as_bytes()) {
+                Ok(_) => {}
+                Err(e) => {
+                    error!(self.log, "db delete: {}", e);
+                    match response.tx.send(()) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            error!(self.log, "response tx: {:?}", e);
+                        }
+                    }
+                    return;
+                }
+            }
+        }
+        match response.tx.send(()) {
+            Ok(_) => {}
+            Err(e) => {
+                error!(self.log, "response tx: {:?}", e);
+            }
+        }
     }
 }

--- a/src/dns_server.rs
+++ b/src/dns_server.rs
@@ -1,0 +1,200 @@
+use std::sync::Arc;
+use std::io::Result;
+use std::str::FromStr;
+use std::net::SocketAddr;
+
+use tokio::net::UdpSocket;
+use pretty_hex::*;
+use slog::{Logger, error};
+use trust_dns_proto::op::header::Header;
+use trust_dns_proto::serialize::binary::{
+    BinDecoder,
+    BinDecodable,
+    BinEncoder,
+};
+use trust_dns_server::authority::{
+    MessageResponseBuilder,
+    MessageRequest,
+};
+use trust_dns_proto::rr::{Record, Name};
+use trust_dns_proto::rr::rdata::SRV;
+use trust_dns_proto::rr::record_data::RData;
+use trust_dns_proto::rr::record_type::RecordType;
+use crate::dns_data::DnsRecord;
+
+pub async fn run(log: Logger, db: Arc::<sled::Db>) -> Result<()> {
+
+    let socket = Arc::new(UdpSocket::bind("::1:4753").await?);
+
+    loop {
+
+        let mut buf = vec![0u8;16384];
+        let (n, src) = socket.recv_from(&mut buf).await?;
+        buf.resize(n, 0);
+
+        let socket = socket.clone();
+        let log = log.clone();
+        let db = db.clone();
+
+        tokio::spawn(async move { handle_req(log, db, socket, src, buf).await });
+
+    }
+
+
+}
+
+async fn handle_req<'a, 'b, 'c>(
+    log: Logger,
+    db: Arc::<sled::Db>,
+    socket: Arc::<UdpSocket>,
+    src: SocketAddr,
+    buf: Vec<u8>,
+) {
+
+    println!("{:?}", buf.hex_dump());
+
+    let mut dec = BinDecoder::new(&buf);
+    let mr = match MessageRequest::read(&mut dec) {
+        Ok(mr) => mr,
+        Err(e) => {
+            error!(log, "read message: {}", e);
+            return;
+        }
+    };
+
+    println!("{:#?}", mr);
+
+    let rb = MessageResponseBuilder::from_message_request(&mr);
+    let header = Header::response_from_request(mr.header());
+
+    let name = mr.query().original().name().clone();
+    let key = name.to_string();
+    let key = key.trim_end_matches('.');
+
+    let bits = match db.get(key.as_bytes()) {
+        Ok(Some(bits)) => bits,
+        Err(e) => {
+            error!(log, "db get: {}", e);
+            nack(&log, &mr, &socket, &header, &src).await;
+            return;
+        }
+        _ => {
+            nack(&log, &mr, &socket, &header, &src).await;
+            return;
+        }
+    };
+
+    let record: crate::dns_data::DnsRecord =
+        match serde_json::from_slice(bits.as_ref()) {
+            Ok(r) => r,
+            Err(e) => {
+                error!(log, "deserialize record: {}", e);
+                return;
+            }
+        };
+
+    match record {
+        DnsRecord::AAAA(addr) => {
+            let mut aaaa = Record::new();
+            aaaa.set_name(name)
+                .set_rr_type(RecordType::AAAA)
+                .set_data(Some(RData::AAAA(addr)));
+
+            let mresp = rb.build(
+                header,
+                vec![&aaaa],
+                vec![],
+                vec![],
+                vec![],
+            );
+
+            let mut resp_data = Vec::new();
+            let mut enc = BinEncoder::new(&mut resp_data);
+            match mresp.destructive_emit(&mut enc) {
+                Ok(_) => {},
+                Err(e) => {
+                    error!(log, "destructive emit: {}", e);
+                    nack(&log, &mr, &socket, &header, &src).await;
+                    return;
+                }
+            }
+            match socket.send_to(&resp_data, &src).await {
+                Ok(_) => {},
+                Err(e) => {
+                    error!(log, "send: {}", e);
+                    return;
+                }
+            }
+        }
+        DnsRecord::SRV(prio, weight, port, target) => {
+            let mut srv = Record::new();
+            let name = match Name::from_str(&target) {
+                Ok(name) => name,
+                Err(e) => {
+                    error!(log, "srv target: '{}' {}", target, e);
+                    nack(&log, &mr, &socket, &header, &src).await;
+                    return;
+                }
+            };
+            srv.set_name(name.clone())
+                .set_rr_type(RecordType::SRV)
+                .set_data(
+                    Some(RData::SRV(SRV::new(prio, weight, port, name)))
+                );
+
+            let mresp = rb.build(
+                header,
+                vec![&srv],
+                vec![],
+                vec![],
+                vec![],
+            );
+
+            let mut resp_data = Vec::new();
+            let mut enc = BinEncoder::new(&mut resp_data);
+            match mresp.destructive_emit(&mut enc) {
+                Ok(_) => {},
+                Err(e) => {
+                    error!(log, "destructive emit: {}", e);
+                    nack(&log, &mr, &socket, &header, &src).await;
+                    return;
+                }
+            }
+            match socket.send_to(&resp_data, &src).await {
+                Ok(_) => {},
+                Err(e) => {
+                    error!(log, "send: {}", e);
+                    return;
+                }
+            }
+        }
+    };
+}
+
+async fn nack(
+    log: &Logger,
+    mr: &MessageRequest,
+    socket: &UdpSocket,
+    header: &Header,
+    src: &SocketAddr,
+) {
+    let rb = MessageResponseBuilder::from_message_request(&mr);
+    let mresp = rb.build_no_records(*header);
+    let mut resp_data = Vec::new();
+    let mut enc = BinEncoder::new(&mut resp_data);
+    match mresp.destructive_emit(&mut enc) {
+        Ok(_) => {}
+        Err(e) => {
+            error!(log, "destructive emit: {}", e);
+            return;
+        }
+    }
+    match socket.send_to(&resp_data, &src).await {
+        Ok(_) => {}
+        Err(e) => {
+            error!(log, "destructive emit: {}", e);
+            return;
+        }
+    }
+
+}

--- a/src/dns_server.rs
+++ b/src/dns_server.rs
@@ -128,18 +128,18 @@ async fn handle_req<'a, 'b, 'c>(
         }
         DnsRecord::SRV(prio, weight, port, target) => {
             let mut srv = Record::new();
-            let name = match Name::from_str(&target) {
-                Ok(name) => name,
+            let tgt = match Name::from_str(&target) {
+                Ok(tgt) => tgt,
                 Err(e) => {
                     error!(log, "srv target: '{}' {}", target, e);
                     nack(&log, &mr, &socket, &header, &src).await;
                     return;
                 }
             };
-            srv.set_name(name.clone())
+            srv.set_name(name)
                 .set_rr_type(RecordType::SRV)
                 .set_data(
-                    Some(RData::SRV(SRV::new(prio, weight, port, name)))
+                    Some(RData::SRV(SRV::new(prio, weight, port, tgt)))
                 );
 
             let mresp = rb.build(

--- a/src/dropshot_server.rs
+++ b/src/dropshot_server.rs
@@ -1,6 +1,10 @@
 //! Dropshot server for configuring DNS namespace
 
-use crate::dns_data;
+use crate::dns_data::{
+    self,
+    DnsRecordKey,
+    DnsRecord,
+};
 use dropshot::endpoint;
 use std::sync::Arc;
 
@@ -21,24 +25,68 @@ pub fn api() -> dropshot::ApiDescription<Arc<Context>> {
     // api.register(dns_zone_put).unwrap();
     // api.register(dns_record_put).unwrap();
     api.register(dns_records_get).unwrap(); // XXX unwrap
+    api.register(dns_records_set).unwrap(); // XXX unwrap
+    api.register(dns_records_delete).unwrap(); // XXX unwrap
     api
 }
 
 #[endpoint(
     method = GET,
-    path = "/dummy",
+    path = "/get-records",
 )]
 async fn dns_records_get(
     rqctx: Arc<dropshot::RequestContext<Arc<Context>>>,
-) -> Result<dropshot::HttpResponseOk<usize>, dropshot::HttpError> {
+) -> Result<
+        dropshot::HttpResponseOk<Vec<(DnsRecordKey,DnsRecord)>>,
+        dropshot::HttpError
+    > 
+{
     let apictx = rqctx.context();
     // XXX record key
     let records = apictx
         .client
-        .get_records(dns_data::DnsRecordKey {})
+        .get_records(None)
         .await
         .map_err(|e| {
             dropshot::HttpError::for_internal_error(format!("uh oh: {:?}", e))
         })?;
-    Ok(dropshot::HttpResponseOk(records.len()))
+    Ok(dropshot::HttpResponseOk(records))
+}
+
+#[endpoint(
+    method = PUT,
+    path = "/set-records",
+)]
+async fn dns_records_set(
+    rqctx: Arc<dropshot::RequestContext<Arc<Context>>>,
+    rq: dropshot::TypedBody<Vec<(DnsRecordKey, DnsRecord)>>,
+) -> Result<dropshot::HttpResponseOk<()>, dropshot::HttpError> {
+    let apictx = rqctx.context();
+    apictx
+        .client
+        .set_records(rq.into_inner())
+        .await
+        .map_err(|e| {
+            dropshot::HttpError::for_internal_error(format!("uh oh: {:?}", e))
+        })?;
+    Ok(dropshot::HttpResponseOk(()))
+}
+
+#[endpoint(
+    method = PUT,
+    path = "/delete-records",
+)]
+async fn dns_records_delete(
+    rqctx: Arc<dropshot::RequestContext<Arc<Context>>>,
+    rq: dropshot::TypedBody<Vec<DnsRecordKey>>,
+) -> Result<dropshot::HttpResponseOk<()>, dropshot::HttpError> {
+    let apictx = rqctx.context();
+    apictx
+        .client
+        .delete_records(rq.into_inner())
+        .await
+        .map_err(|e| {
+            dropshot::HttpError::for_internal_error(format!("uh oh: {:?}", e))
+        })?;
+    Ok(dropshot::HttpResponseOk(()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 use std::sync::Arc;
 
 mod dns_data;
+pub mod dns_server;
 pub mod dropshot_server;
 
 #[derive(Deserialize, Debug)]
@@ -14,14 +15,14 @@ pub struct Config {
 
 pub async fn start_server(
     config: Config,
+    log: slog::Logger,
+    db: Arc::<sled::Db>,
 ) -> Result<dropshot::HttpServer<Arc<dropshot_server::Context>>, anyhow::Error>
 {
-    let log =
-        config.log.to_logger("toy-dns").context("failed to create logger")?;
-
     let data_client = dns_data::Client::new(
         log.new(slog::o!("component" => "DataClient")),
         &config.data,
+        db,
     );
 
     let api = dropshot_server::api();


### PR DESCRIPTION
This PR adds an embedded record store using [sled](https://github.com/spacejam/sled) and an embedded DNS server using [trust-dns](https://github.com/bluejekyll/trust-dns).

This is a minimal prototype. Functions include the following.

- Batch add/remove operations for AAAA and SRV records.
- Local storage.
- DNS query support for AAAA and SRV records.

The readme file contains usage examples.