### PR TITLE
Prep for life outside the toy bin

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -2,6 +2,9 @@
 bind_address = "127.0.0.1:5353"
 request_body_max_bytes = 1048576
 
+[dns]
+bind_address = "127.0.0.1:4753"
+
 [log]
 # Show log messages of this level and more severe
 level = "debug"
@@ -16,3 +19,4 @@ mode = "stderr-terminal"
 
 [data]
 nmax_messages = 16
+storage_path = "/tmp/dns"

--- a/src/bin/toy-dns-server.rs
+++ b/src/bin/toy-dns-server.rs
@@ -32,13 +32,16 @@ async fn main() -> Result<(), anyhow::Error> {
         .to_logger("toy-dns")
         .context("failed to create logger")?;
 
-    let db = Arc::new(sled::open("/tmp/toy-dns-db")?);
+    let db = Arc::new(sled::open(&config.data.storage_path)?);
 
     {
         let db = db.clone();
         let log = log.clone();
+        let config = config.dns.clone();
 
-        tokio::spawn(async move { toy_dns::dns_server::run(log, db).await });
+        tokio::spawn(async move {
+            toy_dns::dns_server::run(log, db, config).await 
+        });
     }
 
     let server = toy_dns::start_server(config, log, db).await?;

--- a/src/bin/toy-dns-server.rs
+++ b/src/bin/toy-dns-server.rs
@@ -28,9 +28,8 @@ async fn main() -> Result<(), anyhow::Error> {
         .with_context(|| format!("parse config file {:?}", config_file))?;
     eprintln!("{:?}", config);
 
-    let log = config.log
-        .to_logger("toy-dns")
-        .context("failed to create logger")?;
+    let log =
+        config.log.to_logger("toy-dns").context("failed to create logger")?;
 
     let db = Arc::new(sled::open(&config.data.storage_path)?);
 
@@ -39,9 +38,9 @@ async fn main() -> Result<(), anyhow::Error> {
         let log = log.clone();
         let config = config.dns.clone();
 
-        tokio::spawn(async move {
-            toy_dns::dns_server::run(log, db, config).await 
-        });
+        tokio::spawn(
+            async move { toy_dns::dns_server::run(log, db, config).await },
+        );
     }
 
     let server = toy_dns::start_server(config, log, db).await?;

--- a/src/dns_data.rs
+++ b/src/dns_data.rs
@@ -11,7 +11,10 @@ use std::sync::Arc;
 #[derive(Deserialize, Debug)]
 pub struct Config {
     /// maximum number of channel messages to buffer
-    nmax_messages: usize,
+    pub nmax_messages: usize,
+
+    /// The path for the embedded kv store
+    pub storage_path: String,
 }
 
 /// default maximum number of messages to buffer
@@ -19,11 +22,13 @@ const NMAX_MESSAGES_DEFAULT: usize = 16;
 
 impl Default for Config {
     fn default() -> Self {
-        Config { nmax_messages: NMAX_MESSAGES_DEFAULT }
+        Config {
+            nmax_messages: NMAX_MESSAGES_DEFAULT,
+            storage_path: ".".into(),
+        }
     }
 }
 
-// XXX
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub enum DnsRecord {
     AAAA(Ipv6Addr),

--- a/src/dns_server.rs
+++ b/src/dns_server.rs
@@ -115,7 +115,6 @@ async fn handle_req<'a, 'b, 'c>(
                 Ok(_) => {}
                 Err(e) => {
                     error!(log, "send: {}", e);
-                    return;
                 }
             }
         }
@@ -149,7 +148,6 @@ async fn handle_req<'a, 'b, 'c>(
                 Ok(_) => {}
                 Err(e) => {
                     error!(log, "send: {}", e);
-                    return;
                 }
             }
         }
@@ -163,7 +161,7 @@ async fn nack(
     header: &Header,
     src: &SocketAddr,
 ) {
-    let rb = MessageResponseBuilder::from_message_request(&mr);
+    let rb = MessageResponseBuilder::from_message_request(mr);
     let mresp = rb.build_no_records(*header);
     let mut resp_data = Vec::new();
     let mut enc = BinEncoder::new(&mut resp_data);
@@ -178,7 +176,6 @@ async fn nack(
         Ok(_) => {}
         Err(e) => {
             error!(log, "destructive emit: {}", e);
-            return;
         }
     }
 }

--- a/src/dns_server.rs
+++ b/src/dns_server.rs
@@ -3,6 +3,8 @@ use std::io::Result;
 use std::str::FromStr;
 use std::net::SocketAddr;
 
+
+use serde::{Deserialize};
 use tokio::net::UdpSocket;
 use pretty_hex::*;
 use slog::{Logger, error};
@@ -22,9 +24,18 @@ use trust_dns_proto::rr::record_data::RData;
 use trust_dns_proto::rr::record_type::RecordType;
 use crate::dns_data::DnsRecord;
 
-pub async fn run(log: Logger, db: Arc::<sled::Db>) -> Result<()> {
+/// Configuration related to the DNS server
+#[derive(Deserialize, Debug, Clone)]
+pub struct Config {
+    /// The address to listen for DNS requests on
+    bind_address: String,
+}
 
-    let socket = Arc::new(UdpSocket::bind("::1:4753").await?);
+pub async fn run(log: Logger, db: Arc::<sled::Db>, config: Config) -> Result<()> {
+
+    let socket = Arc::new(
+        UdpSocket::bind(config.bind_address).await?
+    );
 
     loop {
 

--- a/src/dns_server.rs
+++ b/src/dns_server.rs
@@ -1,28 +1,22 @@
-use std::sync::Arc;
 use std::io::Result;
-use std::str::FromStr;
 use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::Arc;
 
-
-use serde::{Deserialize};
-use tokio::net::UdpSocket;
+use crate::dns_data::DnsRecord;
 use pretty_hex::*;
-use slog::{Logger, error};
+use serde::Deserialize;
+use slog::{error, Logger};
+use tokio::net::UdpSocket;
 use trust_dns_proto::op::header::Header;
-use trust_dns_proto::serialize::binary::{
-    BinDecoder,
-    BinDecodable,
-    BinEncoder,
-};
-use trust_dns_server::authority::{
-    MessageResponseBuilder,
-    MessageRequest,
-};
-use trust_dns_proto::rr::{Record, Name};
 use trust_dns_proto::rr::rdata::SRV;
 use trust_dns_proto::rr::record_data::RData;
 use trust_dns_proto::rr::record_type::RecordType;
-use crate::dns_data::DnsRecord;
+use trust_dns_proto::rr::{Name, Record};
+use trust_dns_proto::serialize::binary::{
+    BinDecodable, BinDecoder, BinEncoder,
+};
+use trust_dns_server::authority::{MessageRequest, MessageResponseBuilder};
 
 /// Configuration related to the DNS server
 #[derive(Deserialize, Debug, Clone)]
@@ -31,15 +25,11 @@ pub struct Config {
     bind_address: String,
 }
 
-pub async fn run(log: Logger, db: Arc::<sled::Db>, config: Config) -> Result<()> {
-
-    let socket = Arc::new(
-        UdpSocket::bind(config.bind_address).await?
-    );
+pub async fn run(log: Logger, db: Arc<sled::Db>, config: Config) -> Result<()> {
+    let socket = Arc::new(UdpSocket::bind(config.bind_address).await?);
 
     loop {
-
-        let mut buf = vec![0u8;16384];
+        let mut buf = vec![0u8; 16384];
         let (n, src) = socket.recv_from(&mut buf).await?;
         buf.resize(n, 0);
 
@@ -47,21 +37,19 @@ pub async fn run(log: Logger, db: Arc::<sled::Db>, config: Config) -> Result<()>
         let log = log.clone();
         let db = db.clone();
 
-        tokio::spawn(async move { handle_req(log, db, socket, src, buf).await });
-
+        tokio::spawn(
+            async move { handle_req(log, db, socket, src, buf).await },
+        );
     }
-
-
 }
 
 async fn handle_req<'a, 'b, 'c>(
     log: Logger,
-    db: Arc::<sled::Db>,
-    socket: Arc::<UdpSocket>,
+    db: Arc<sled::Db>,
+    socket: Arc<UdpSocket>,
     src: SocketAddr,
     buf: Vec<u8>,
 ) {
-
     println!("{:?}", buf.hex_dump());
 
     let mut dec = BinDecoder::new(&buf);
@@ -111,18 +99,12 @@ async fn handle_req<'a, 'b, 'c>(
                 .set_rr_type(RecordType::AAAA)
                 .set_data(Some(RData::AAAA(addr)));
 
-            let mresp = rb.build(
-                header,
-                vec![&aaaa],
-                vec![],
-                vec![],
-                vec![],
-            );
+            let mresp = rb.build(header, vec![&aaaa], vec![], vec![], vec![]);
 
             let mut resp_data = Vec::new();
             let mut enc = BinEncoder::new(&mut resp_data);
             match mresp.destructive_emit(&mut enc) {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(e) => {
                     error!(log, "destructive emit: {}", e);
                     nack(&log, &mr, &socket, &header, &src).await;
@@ -130,7 +112,7 @@ async fn handle_req<'a, 'b, 'c>(
                 }
             }
             match socket.send_to(&resp_data, &src).await {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(e) => {
                     error!(log, "send: {}", e);
                     return;
@@ -149,22 +131,14 @@ async fn handle_req<'a, 'b, 'c>(
             };
             srv.set_name(name)
                 .set_rr_type(RecordType::SRV)
-                .set_data(
-                    Some(RData::SRV(SRV::new(prio, weight, port, tgt)))
-                );
+                .set_data(Some(RData::SRV(SRV::new(prio, weight, port, tgt))));
 
-            let mresp = rb.build(
-                header,
-                vec![&srv],
-                vec![],
-                vec![],
-                vec![],
-            );
+            let mresp = rb.build(header, vec![&srv], vec![], vec![], vec![]);
 
             let mut resp_data = Vec::new();
             let mut enc = BinEncoder::new(&mut resp_data);
             match mresp.destructive_emit(&mut enc) {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(e) => {
                     error!(log, "destructive emit: {}", e);
                     nack(&log, &mr, &socket, &header, &src).await;
@@ -172,7 +146,7 @@ async fn handle_req<'a, 'b, 'c>(
                 }
             }
             match socket.send_to(&resp_data, &src).await {
-                Ok(_) => {},
+                Ok(_) => {}
                 Err(e) => {
                     error!(log, "send: {}", e);
                     return;
@@ -207,5 +181,4 @@ async fn nack(
             return;
         }
     }
-
 }

--- a/src/dropshot_server.rs
+++ b/src/dropshot_server.rs
@@ -17,12 +17,9 @@ impl Context {
 pub fn api() -> dropshot::ApiDescription<Arc<Context>> {
     let mut api = dropshot::ApiDescription::new();
 
-    // XXX
-    // api.register(dns_zone_put).unwrap();
-    // api.register(dns_record_put).unwrap();
-    api.register(dns_records_get).unwrap(); // XXX unwrap
-    api.register(dns_records_set).unwrap(); // XXX unwrap
-    api.register(dns_records_delete).unwrap(); // XXX unwrap
+    api.register(dns_records_get).expect("register dns_records_get");
+    api.register(dns_records_set).expect("register dns_records_set");
+    api.register(dns_records_delete).expect("register dns_records_delete");
     api
 }
 

--- a/src/dropshot_server.rs
+++ b/src/dropshot_server.rs
@@ -1,10 +1,6 @@
 //! Dropshot server for configuring DNS namespace
 
-use crate::dns_data::{
-    self,
-    DnsRecordKey,
-    DnsRecord,
-};
+use crate::dns_data::{self, DnsRecord, DnsRecordKey};
 use dropshot::endpoint;
 use std::sync::Arc;
 
@@ -37,19 +33,14 @@ pub fn api() -> dropshot::ApiDescription<Arc<Context>> {
 async fn dns_records_get(
     rqctx: Arc<dropshot::RequestContext<Arc<Context>>>,
 ) -> Result<
-        dropshot::HttpResponseOk<Vec<(DnsRecordKey,DnsRecord)>>,
-        dropshot::HttpError
-    > 
-{
+    dropshot::HttpResponseOk<Vec<(DnsRecordKey, DnsRecord)>>,
+    dropshot::HttpError,
+> {
     let apictx = rqctx.context();
     // XXX record key
-    let records = apictx
-        .client
-        .get_records(None)
-        .await
-        .map_err(|e| {
-            dropshot::HttpError::for_internal_error(format!("uh oh: {:?}", e))
-        })?;
+    let records = apictx.client.get_records(None).await.map_err(|e| {
+        dropshot::HttpError::for_internal_error(format!("uh oh: {:?}", e))
+    })?;
     Ok(dropshot::HttpResponseOk(records))
 }
 
@@ -62,13 +53,9 @@ async fn dns_records_set(
     rq: dropshot::TypedBody<Vec<(DnsRecordKey, DnsRecord)>>,
 ) -> Result<dropshot::HttpResponseOk<()>, dropshot::HttpError> {
     let apictx = rqctx.context();
-    apictx
-        .client
-        .set_records(rq.into_inner())
-        .await
-        .map_err(|e| {
-            dropshot::HttpError::for_internal_error(format!("uh oh: {:?}", e))
-        })?;
+    apictx.client.set_records(rq.into_inner()).await.map_err(|e| {
+        dropshot::HttpError::for_internal_error(format!("uh oh: {:?}", e))
+    })?;
     Ok(dropshot::HttpResponseOk(()))
 }
 
@@ -81,12 +68,8 @@ async fn dns_records_delete(
     rq: dropshot::TypedBody<Vec<DnsRecordKey>>,
 ) -> Result<dropshot::HttpResponseOk<()>, dropshot::HttpError> {
     let apictx = rqctx.context();
-    apictx
-        .client
-        .delete_records(rq.into_inner())
-        .await
-        .map_err(|e| {
-            dropshot::HttpError::for_internal_error(format!("uh oh: {:?}", e))
-        })?;
+    apictx.client.delete_records(rq.into_inner()).await.map_err(|e| {
+        dropshot::HttpError::for_internal_error(format!("uh oh: {:?}", e))
+    })?;
     Ok(dropshot::HttpResponseOk(()))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub struct Config {
 pub async fn start_server(
     config: Config,
     log: slog::Logger,
-    db: Arc::<sled::Db>,
+    db: Arc<sled::Db>,
 ) -> Result<dropshot::HttpServer<Arc<dropshot_server::Context>>, anyhow::Error>
 {
     let data_client = dns_data::Client::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub struct Config {
     pub log: dropshot::ConfigLogging,
     pub dropshot: dropshot::ConfigDropshot,
     pub data: dns_data::Config,
+    pub dns: dns_server::Config,
 }
 
 pub async fn start_server(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity)]
+
 use anyhow::Context;
 use serde::Deserialize;
 use std::sync::Arc;


### PR DESCRIPTION
- Add DNS bind-address and data storage path to config and replace corresponding hard-coded values in code.
- Cargo formatting.
- Fix clippy issues.
- Replace dropshot API registration unwraps with expect.

On the last point, this is when the server first starts up, so I think it's OK to have expect statements here. It gives us the semantics of either we start up with the expected handlers, or we do not start at all.